### PR TITLE
Improve definition caching

### DIFF
--- a/handlers/definition-create.js
+++ b/handlers/definition-create.js
@@ -7,6 +7,7 @@ const ABBootstrap = require("../AppBuilder/ABBootstrap");
 // {ABBootstrap}
 // responsible for initializing and returning an {ABFactory} that will work
 // with the current tenant for the incoming request.
+const cacheUpdate = require("../utils/cacheUpdate");
 
 module.exports = {
    /**
@@ -84,6 +85,7 @@ module.exports = {
             req.retry(() => AB.definitionCreate(req, def))
                .then((definition) => {
                   fullDefinition = definition.toObj();
+                  cacheUpdate(AB);
                   cb(null, fullDefinition);
                })
                .then(() => {

--- a/handlers/definition-delete.js
+++ b/handlers/definition-delete.js
@@ -7,6 +7,7 @@ const ABBootstrap = require("../AppBuilder/ABBootstrap");
 // {ABBootstrap}
 // responsible for initializing and returning an {ABFactory} that will work
 // with the current tenant for the incoming request.
+const cacheUpdate = require("../utils/cacheUpdate");
 
 module.exports = {
    /**
@@ -64,6 +65,7 @@ module.exports = {
                return req
                   .retry(() => AB.definitionDestroy(req, id))
                   .then(() => {
+                     cacheUpdate(AB);
                      cb(null, fullDefinition);
                   })
                   .then(() => {

--- a/handlers/definition-update.js
+++ b/handlers/definition-update.js
@@ -7,6 +7,7 @@ const ABBootstrap = require("../AppBuilder/ABBootstrap");
 // {ABBootstrap}
 // responsible for initializing and returning an {ABFactory} that will work
 // with the current tenant for the incoming request.
+const cacheUpdate = require("../utils/cacheUpdate");
 
 module.exports = {
    /**
@@ -66,6 +67,7 @@ module.exports = {
             req.retry(() => AB.definitionUpdate(req, id, values))
                .then((definition) => {
                   fullDefinition = definition.toObj();
+                  cacheUpdate(AB);
                   cb(null, fullDefinition);
                })
                .then(() => {

--- a/handlers/definitions-check-update.js
+++ b/handlers/definitions-check-update.js
@@ -1,0 +1,45 @@
+/**
+ * definitions-check-update
+ * Check for the date definitions where last updated
+ * (When defs-for-role cache was last cleared)
+ * our Request handler.
+ */
+
+const ABBootstrap = require("../AppBuilder/ABBootstrap");
+
+module.exports = {
+   /**
+    * Key: the cote message key we respond to.
+    */
+   key: "definition_manager.definitions-check-update",
+
+   /**
+    * inputValidation
+    * define the expected inputs to this service handler:
+    */
+   inputValidation: {},
+
+   /**
+    * fn
+    * our Request handler.
+    * @param {obj} req
+    *        the request object sent by the api_sails/api/controllers/definition_manager/definitionsForRoles.
+    * @param {fn} cb
+    *        a node style callback(err, results) to send data when job is finished
+    */
+   fn: function handler(req, cb) {
+      //
+
+      ABBootstrap.init(req)
+         .then((AB) => {
+            if (!AB.cache("defs-for-role-updated")) {
+               AB.cache("defs-for-role-updated", Date.now());
+            }
+            const updated = AB.cache("defs-for-role-updated");
+            cb(null, updated);
+         })
+         .catch((err) => {
+            console.log(err);
+         });
+   },
+};

--- a/handlers/definitionsForRoles.js
+++ b/handlers/definitionsForRoles.js
@@ -32,8 +32,6 @@ module.exports = {
       var ServiceKey = this.key;
       req.log(ServiceKey);
 
-      let tenantID = req.tenantID();
-
       // Get the passed in parameters
       var roles = req.param("roles");
       let roleIDs = roles.map((r) => r.uuid);
@@ -43,7 +41,7 @@ module.exports = {
 
       ABBootstrap.init(req)
          .then((AB) => {
-            let hashIDs = AB.cache(ServiceKey);
+            let hashIDs = AB.cache("defs-for-role");
             if (!hashIDs) hashIDs = {};
 
             var ids = [];
@@ -69,7 +67,7 @@ module.exports = {
                   a.exportIDs(aIDs);
                });
                hashIDs[hashKey] = aIDs;
-               AB.cache(ServiceKey, hashIDs);
+               AB.cache("defs-for-role", hashIDs);
             }
 
             ids = hashIDs[hashKey];

--- a/handlers/json-import.js
+++ b/handlers/json-import.js
@@ -7,6 +7,7 @@ const ABBootstrap = require("../AppBuilder/ABBootstrap");
 // {ABBootstrap}
 // responsible for initializing and returning an {ABFactory} that will work
 // with the current tenant for the incoming request.
+const cacheUpdate = require("../utils/cacheUpdate");
 
 module.exports = {
    /**
@@ -136,6 +137,8 @@ module.exports = {
                   }
                });
             }
+
+            cacheUpdate(AB);
 
             return new Promise((resolve, reject) => {
                Promise.resolve()

--- a/utils/cacheUpdate.js
+++ b/utils/cacheUpdate.js
@@ -1,0 +1,7 @@
+module.exports = (AB) => {
+   console.log("Definitions Cache Cleared!");
+   // Clear the cached definitions for role
+   AB.Cache("defs-for-role", {});
+   // Store the date last updated
+   AB.Cache("defs-for-role-updated", Date.now());
+};


### PR DESCRIPTION
- clear cache on definition changes
- cache the time the definitions cache was last cleared
- return the time in a new route so that frontend can now if the definitions need to be updated.